### PR TITLE
Remove guice multibindings dependency

### DIFF
--- a/plugins/plugin-myjson/plugin-myjson-server/pom.xml
+++ b/plugins/plugin-myjson/plugin-myjson-server/pom.xml
@@ -24,10 +24,6 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.google.inject.extensions</groupId>
-            <artifactId>guice-multibindings</artifactId>
-        </dependency>
-        <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
         </dependency>


### PR DESCRIPTION
Changes related to PR https://github.com/eclipse/che-parent/pull/93

Remove guice-multibindings dependency (that became a part of guice core library) 